### PR TITLE
feat: add campaign retry endpoint for failed messages

### DIFF
--- a/prospectio_api_mcp/application/api/leads_routes.py
+++ b/prospectio_api_mcp/application/api/leads_routes.py
@@ -9,6 +9,7 @@ from application.requests.campaign import CreateCampaignRequest
 from application.use_cases.generate_message import GenerateMessageUseCase
 from application.use_cases.generate_campaign import GenerateCampaignUseCase
 from application.use_cases.generate_campaign_stream import GenerateCampaignStreamUseCase
+from application.use_cases.retry_campaign_stream import RetryCampaignStreamUseCase
 from application.use_cases.get_leads import GetLeadsUseCase
 from domain.entities.company import CompanyEntity
 from domain.entities.contact import ContactEntity
@@ -341,6 +342,50 @@ def leads_router(
             )
         except Exception as e:
             logger.error(f"Error in generate campaign stream: {e}\n{traceback.format_exc()}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @leads_router.post("/campaigns/{campaign_id}/retry/stream")
+    async def retry_campaign_stream(
+        campaign_id: str = Path(..., description="The campaign ID to retry failed messages for"),
+    ) -> StreamingResponse:
+        """
+        Retry failed campaign messages with SSE streaming.
+
+        Re-generates only the failed messages of an existing campaign.
+        Failed message records are deleted before re-generation.
+
+        Event types:
+        - campaign_started: Retry started with campaign_id
+        - progress_update: X/Y failed messages retried
+        - message_generated: Each re-generated message
+        - campaign_completed: Final summary with updated counters
+        - campaign_failed: Error occurred
+
+        Args:
+            campaign_id (str): The campaign ID to retry.
+
+        Returns:
+            StreamingResponse: SSE stream of retry events.
+        """
+        try:
+            use_case = RetryCampaignStreamUseCase(
+                campaign_id=campaign_id,
+                profile_repository=profile_repository,
+                campaign_repository=campaign_repository,
+                message_port=message_port,
+            )
+
+            return StreamingResponse(
+                use_case.retry_campaign_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+        except Exception as e:
+            logger.error(f"Error in retry campaign stream: {e}\n{traceback.format_exc()}")
             raise HTTPException(status_code=500, detail=str(e))
 
     @leads_router.get("/campaign/result/{task_id}")

--- a/prospectio_api_mcp/application/use_cases/retry_campaign_stream.py
+++ b/prospectio_api_mcp/application/use_cases/retry_campaign_stream.py
@@ -1,0 +1,267 @@
+import datetime
+from typing import AsyncGenerator, Optional
+import logging
+from domain.entities.campaign import Campaign, CampaignStatus
+from domain.entities.campaign_result import CampaignMessage
+from domain.entities.contact import Contact
+from domain.entities.company import Company
+from domain.entities.sse_events import (
+    SSEEvent,
+    SSEEventType,
+    CampaignProgressData,
+    MessageGeneratedData,
+)
+from domain.ports.generate_message import GenerateMessagePort
+from domain.ports.profile_respository import ProfileRepositoryPort
+from domain.ports.campaign_repository import CampaignRepositoryPort
+
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime.datetime:
+    """Return current UTC datetime."""
+    return datetime.datetime.now(datetime.UTC)
+
+
+class RetryCampaignStreamUseCase:
+    """
+    Use case for retrying failed campaign messages with real-time SSE streaming.
+    Deletes old failed messages, re-generates them, and yields events as they are processed.
+    """
+
+    def __init__(
+        self,
+        campaign_id: str,
+        profile_repository: ProfileRepositoryPort,
+        campaign_repository: CampaignRepositoryPort,
+        message_port: GenerateMessagePort,
+    ):
+        """
+        Initialize the retry streaming use case.
+
+        Args:
+            campaign_id: ID of the campaign to retry failed messages for.
+            profile_repository: Repository for accessing user profile.
+            campaign_repository: Repository for campaign and message persistence.
+            message_port: Port for generating prospecting messages.
+        """
+        self.campaign_id = campaign_id
+        self.profile_repository = profile_repository
+        self.campaign_repository = campaign_repository
+        self.message_port = message_port
+
+    def _create_campaign_message(
+        self,
+        campaign_id: Optional[str],
+        contact: Contact,
+        company: Company,
+        subject: str,
+        message: str,
+        status: str,
+        error: Optional[str] = None,
+    ) -> CampaignMessage:
+        """Create a CampaignMessage with common fields populated."""
+        return CampaignMessage(
+            campaign_id=campaign_id,
+            contact_id=contact.id or "",
+            contact_name=contact.name,
+            contact_email=contact.email,
+            company_name=company.name,
+            subject=subject,
+            message=message,
+            status=status,
+            error=error,
+            created_at=_utc_now(),
+        )
+
+    def _create_message_event(self, saved_message: CampaignMessage) -> str:
+        """Create SSE event for a generated message."""
+        return SSEEvent(
+            event=SSEEventType.MESSAGE_GENERATED,
+            data=MessageGeneratedData(
+                campaign_id=saved_message.campaign_id or "",
+                message_id=saved_message.id or "",
+                contact_id=saved_message.contact_id,
+                contact_name=saved_message.contact_name,
+                contact_email=saved_message.contact_email,
+                company_name=saved_message.company_name,
+                subject=saved_message.subject,
+                message=saved_message.message,
+                status=saved_message.status,
+                error=saved_message.error,
+                created_at=saved_message.created_at or _utc_now(),
+            ).model_dump(),
+        ).to_sse_format()
+
+    async def retry_campaign_stream(self) -> AsyncGenerator[str, None]:
+        """
+        Retry failed campaign messages with SSE streaming.
+
+        Yields:
+            str: SSE-formatted event strings.
+        """
+        campaign: Optional[Campaign] = None
+        successful = 0
+        failed = 0
+        total_to_retry = 0
+
+        try:
+            # Fetch campaign by ID
+            campaign = await self.campaign_repository.get_campaign_by_id(self.campaign_id)
+            if not campaign:
+                yield SSEEvent(
+                    event=SSEEventType.CAMPAIGN_FAILED,
+                    data={"error": f"Campaign not found with id: {self.campaign_id}"},
+                ).to_sse_format()
+                return
+
+            # Validate campaign status
+            if campaign.status not in (CampaignStatus.COMPLETED, CampaignStatus.FAILED):
+                yield SSEEvent(
+                    event=SSEEventType.CAMPAIGN_FAILED,
+                    data={"error": f"Cannot retry campaign with status '{campaign.status.value}'. Only COMPLETED or FAILED campaigns can be retried."},
+                ).to_sse_format()
+                return
+
+            # Fetch user profile
+            profile = await self.profile_repository.get_profile()
+            if not profile:
+                yield SSEEvent(
+                    event=SSEEventType.CAMPAIGN_FAILED,
+                    data={"error": "Profile not found. Please create a profile first."},
+                ).to_sse_format()
+                return
+
+            # Fetch failed messages with contacts
+            failed_messages_with_contacts = (
+                await self.campaign_repository.get_failed_messages_with_contacts(self.campaign_id)
+            )
+
+            # If no failed messages, emit completion and return
+            if not failed_messages_with_contacts:
+                yield SSEEvent(
+                    event=SSEEventType.CAMPAIGN_COMPLETED,
+                    data={
+                        "campaign_id": campaign.id,
+                        "total_contacts": 0,
+                        "successful": campaign.successful,
+                        "failed": 0,
+                        "message": "No failed messages to retry.",
+                    },
+                ).to_sse_format()
+                return
+
+            total_to_retry = len(failed_messages_with_contacts)
+            previous_successful = campaign.successful
+
+            # Set campaign to IN_PROGRESS
+            campaign.status = CampaignStatus.IN_PROGRESS
+            campaign.completed_at = None
+            await self.campaign_repository.update_campaign(campaign)
+
+            # Emit campaign started event
+            yield SSEEvent(
+                event=SSEEventType.CAMPAIGN_STARTED,
+                data={"campaign_id": campaign.id, "campaign_name": campaign.name},
+            ).to_sse_format()
+
+            # Process each failed message
+            for index, (old_message, contact, company) in enumerate(failed_messages_with_contacts):
+                current = index + 1
+                percentage = round((current / total_to_retry) * 100, 1)
+
+                # Emit progress update
+                yield SSEEvent(
+                    event=SSEEventType.PROGRESS_UPDATE,
+                    data=CampaignProgressData(
+                        campaign_id=campaign.id or "",
+                        current=current,
+                        total=total_to_retry,
+                        percentage=percentage,
+                        current_contact_name=contact.name,
+                    ).model_dump(),
+                ).to_sse_format()
+
+                # Delete old failed message
+                await self.campaign_repository.delete_message(old_message.id or "")
+
+                try:
+                    prospect_message = await self.message_port.get_message(
+                        profile, contact, company
+                    )
+                    campaign_message = self._create_campaign_message(
+                        campaign.id,
+                        contact,
+                        company,
+                        subject=prospect_message.subject,
+                        message=prospect_message.message,
+                        status="success",
+                    )
+                    saved_message = await self.campaign_repository.save_message(
+                        campaign_message
+                    )
+                    successful += 1
+                    yield self._create_message_event(saved_message)
+
+                except Exception as e:
+                    logger.warning(f"Failed to generate message for contact {contact.id}: {e}")
+                    campaign_message = self._create_campaign_message(
+                        campaign.id,
+                        contact,
+                        company,
+                        subject="",
+                        message="",
+                        status="failed",
+                        error=str(e),
+                    )
+                    saved_message = await self.campaign_repository.save_message(
+                        campaign_message
+                    )
+                    failed += 1
+                    yield self._create_message_event(saved_message)
+
+                # Update campaign stats after each message
+                campaign.successful = previous_successful + successful
+                campaign.failed = failed
+                await self.campaign_repository.update_campaign(campaign)
+
+            # Mark campaign as completed or failed
+            campaign.status = (
+                CampaignStatus.FAILED if failed == total_to_retry else CampaignStatus.COMPLETED
+            )
+            campaign.completed_at = _utc_now()
+            await self.campaign_repository.update_campaign(campaign)
+
+            # Emit completion event
+            yield SSEEvent(
+                event=SSEEventType.CAMPAIGN_COMPLETED,
+                data={
+                    "campaign_id": campaign.id,
+                    "total_contacts": total_to_retry,
+                    "successful": successful,
+                    "failed": failed,
+                    "message": f"Retry completed: {successful} successful, {failed} failed",
+                },
+            ).to_sse_format()
+
+        except Exception as e:
+            logger.error(f"Unexpected error in campaign retry stream: {e}")
+            if campaign and campaign.id:
+                try:
+                    campaign.status = CampaignStatus.FAILED
+                    campaign.completed_at = _utc_now()
+                    await self.campaign_repository.update_campaign(campaign)
+                except Exception as update_error:
+                    logger.error(f"Failed to update campaign status on error: {update_error}")
+
+            yield SSEEvent(
+                event=SSEEventType.CAMPAIGN_FAILED,
+                data={
+                    "campaign_id": campaign.id if campaign else None,
+                    "error": f"Unexpected error: {str(e)}",
+                    "total_contacts": total_to_retry,
+                    "successful": successful,
+                    "failed": failed,
+                },
+            ).to_sse_format()

--- a/prospectio_api_mcp/domain/ports/campaign_repository.py
+++ b/prospectio_api_mcp/domain/ports/campaign_repository.py
@@ -118,3 +118,29 @@ class CampaignRepositoryPort(ABC):
             bool: True if contact has a message, False otherwise.
         """
         pass
+
+    @abstractmethod
+    async def get_failed_messages_with_contacts(
+        self, campaign_id: str
+    ) -> List[Tuple[CampaignMessage, Contact, Company]]:
+        """
+        Return failed messages with their associated contact and company.
+
+        Args:
+            campaign_id (str): The campaign ID to get failed messages for.
+
+        Returns:
+            List[Tuple[CampaignMessage, Contact, Company]]: List of failed message,
+                contact, and company triples.
+        """
+        pass
+
+    @abstractmethod
+    async def delete_message(self, message_id: str) -> None:
+        """
+        Delete a message record by ID.
+
+        Args:
+            message_id (str): The unique identifier of the message to delete.
+        """
+        pass

--- a/prospectio_api_mcp/infrastructure/services/campaign_database.py
+++ b/prospectio_api_mcp/infrastructure/services/campaign_database.py
@@ -3,7 +3,7 @@ import datetime
 from math import ceil
 import uuid
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy import select, exists, or_
+from sqlalchemy import select, exists, or_, delete
 from domain.ports.campaign_repository import CampaignRepositoryPort
 from domain.entities.campaign import Campaign, CampaignEntity, CampaignStatus
 from domain.entities.campaign_result import CampaignMessage
@@ -276,6 +276,57 @@ class CampaignDatabase(CampaignRepositoryPort):
                     result.append((contact, company))
 
             return result
+
+    async def get_failed_messages_with_contacts(
+        self, campaign_id: str
+    ) -> List[Tuple[CampaignMessage, Contact, Company]]:
+        """
+        Return failed messages with their associated contact and company.
+
+        Args:
+            campaign_id (str): The campaign ID to get failed messages for.
+
+        Returns:
+            List[Tuple[CampaignMessage, Contact, Company]]: List of failed message,
+                contact, and company triples.
+        """
+        async with AsyncSession(self.engine) as session:
+            result = await session.execute(
+                select(MessageDB, ContactDB, CompanyDB)
+                .join(ContactDB, MessageDB.contact_id == ContactDB.id)
+                .join(CompanyDB, ContactDB.company_id == CompanyDB.id)
+                .where(
+                    MessageDB.campaign_id == campaign_id,
+                    MessageDB.status == "failed",
+                )
+            )
+            rows = result.all()
+
+            return [
+                (
+                    self._convert_db_to_message(message_db),
+                    self._convert_db_to_contact(contact_db, company_db.name, None),
+                    self._convert_db_to_company(company_db),
+                )
+                for message_db, contact_db, company_db in rows
+            ]
+
+    async def delete_message(self, message_id: str) -> None:
+        """
+        Delete a message record by ID.
+
+        Args:
+            message_id (str): The unique identifier of the message to delete.
+        """
+        async with AsyncSession(self.engine) as session:
+            try:
+                await session.execute(
+                    delete(MessageDB).where(MessageDB.id == message_id)
+                )
+                await session.commit()
+            except Exception as e:
+                await session.rollback()
+                raise e
 
     async def contact_has_message(self, contact_id: str) -> bool:
         """

--- a/tests/doubles/repositories.py
+++ b/tests/doubles/repositories.py
@@ -20,6 +20,7 @@ class FakeCampaignRepository(CampaignRepositoryPort):
         self._campaigns: dict[str, Campaign] = {}
         self._messages: dict[str, CampaignMessage] = {}
         self._contacts_with_companies: List[Tuple[Contact, Company]] = []
+        self._failed_messages_with_contacts: dict[str, List[Tuple[CampaignMessage, Contact, Company]]] = {}
 
     async def create_campaign(self, campaign: Campaign) -> Campaign:
         """Create a new campaign with auto-generated ID."""
@@ -69,6 +70,16 @@ class FakeCampaignRepository(CampaignRepositoryPort):
         """Check if a contact already has a message generated."""
         return any(m.contact_id == contact_id for m in self._messages.values())
 
+    async def get_failed_messages_with_contacts(
+        self, campaign_id: str
+    ) -> List[Tuple[CampaignMessage, Contact, Company]]:
+        """Return failed messages with their associated contact and company."""
+        return self._failed_messages_with_contacts.get(campaign_id, [])
+
+    async def delete_message(self, message_id: str) -> None:
+        """Delete a message record by ID."""
+        self._messages.pop(message_id, None)
+
     # Helper methods for test setup (not in interface)
     def add_contacts_with_companies(
         self, contacts_with_companies: List[Tuple[Contact, Company]]
@@ -84,11 +95,20 @@ class FakeCampaignRepository(CampaignRepositoryPort):
         """Return all campaigns."""
         return list(self._campaigns.values())
 
+    def add_failed_messages_with_contacts(
+        self,
+        campaign_id: str,
+        failed_messages: List[Tuple[CampaignMessage, Contact, Company]],
+    ) -> None:
+        """Configure failed messages that will be returned by get_failed_messages_with_contacts."""
+        self._failed_messages_with_contacts[campaign_id] = failed_messages
+
     def clear(self) -> None:
         """Reset the fake repository."""
         self._campaigns.clear()
         self._messages.clear()
         self._contacts_with_companies.clear()
+        self._failed_messages_with_contacts.clear()
 
 
 class FakeProfileRepository(ProfileRepositoryPort):

--- a/tests/ut/test_campaign_repository.py
+++ b/tests/ut/test_campaign_repository.py
@@ -144,6 +144,34 @@ class FakeCampaignRepository(CampaignRepositoryPort):
         """Check if a contact already has a message generated."""
         return contact_id in self._contact_messages
 
+    async def get_failed_messages_with_contacts(
+        self, campaign_id: str
+    ) -> List[Tuple[CampaignMessage, Contact, Company]]:
+        """Return failed messages with their associated contact and company."""
+        result: List[Tuple[CampaignMessage, Contact, Company]] = []
+        for msg in self._messages.values():
+            if msg.campaign_id == campaign_id and msg.status == "failed":
+                contact = self._contacts.get(msg.contact_id)
+                if contact and contact.company_id:
+                    company = self._companies.get(contact.company_id)
+                    if company:
+                        result.append((msg, contact, company))
+        return result
+
+    async def delete_message(self, message_id: str) -> None:
+        """Delete a message record by ID."""
+        if message_id in self._messages:
+            msg = self._messages[message_id]
+            # Clean up contact_messages tracking
+            if msg.contact_id in self._contact_messages:
+                self._contact_messages[msg.contact_id] = [
+                    mid for mid in self._contact_messages[msg.contact_id]
+                    if mid != message_id
+                ]
+                if not self._contact_messages[msg.contact_id]:
+                    del self._contact_messages[msg.contact_id]
+            del self._messages[message_id]
+
     # Helper methods for test setup (not in interface)
     def add_contact(self, contact: Contact) -> None:
         """Add a contact to the fake store."""

--- a/tests/ut/test_retry_campaign_stream.py
+++ b/tests/ut/test_retry_campaign_stream.py
@@ -1,0 +1,447 @@
+"""Unit tests for RetryCampaignStreamUseCase."""
+
+import json
+import pytest
+from typing import List
+
+from domain.entities.campaign import Campaign, CampaignStatus
+from domain.entities.campaign_result import CampaignMessage
+from domain.entities.company import Company
+from domain.entities.contact import Contact
+from domain.entities.profile import Profile
+from domain.entities.prospect_message import ProspectMessage
+from application.use_cases.retry_campaign_stream import RetryCampaignStreamUseCase
+from tests.doubles.repositories import FakeCampaignRepository, FakeProfileRepository
+from tests.doubles.ports import FakeGenerateMessagePort
+
+
+class TestRetryCampaignStreamUseCase:
+    """Tests for RetryCampaignStreamUseCase."""
+
+    CAMPAIGN_ID = "campaign-retry-001"
+
+    @pytest.fixture
+    def fake_profile_repository(self) -> FakeProfileRepository:
+        """Fresh fake profile repository."""
+        return FakeProfileRepository()
+
+    @pytest.fixture
+    def fake_campaign_repository(self) -> FakeCampaignRepository:
+        """Fresh fake campaign repository."""
+        return FakeCampaignRepository()
+
+    @pytest.fixture
+    def fake_message_port(self) -> FakeGenerateMessagePort:
+        """Fresh fake message port."""
+        return FakeGenerateMessagePort()
+
+    @pytest.fixture
+    def sample_profile(self) -> Profile:
+        """Sample user profile for testing."""
+        return Profile(
+            job_title="Senior Python Developer",
+            location="Paris, France",
+            bio="Experienced developer specializing in FastAPI and clean architecture.",
+            work_experience=[],
+            technos=["Python", "FastAPI", "PostgreSQL"],
+        )
+
+    @pytest.fixture
+    def completed_campaign(self, fake_campaign_repository: FakeCampaignRepository) -> Campaign:
+        """A completed campaign with some successful and failed messages."""
+        campaign = Campaign(
+            id=self.CAMPAIGN_ID,
+            name="Test Campaign",
+            status=CampaignStatus.COMPLETED,
+            total_contacts=3,
+            successful=1,
+            failed=2,
+        )
+        # Manually insert into fake repo
+        fake_campaign_repository._campaigns[campaign.id] = campaign
+        return campaign
+
+    @pytest.fixture
+    def failed_messages_with_contacts(self) -> List[tuple[CampaignMessage, Contact, Company]]:
+        """Failed messages with their contacts and companies for retry."""
+        return [
+            (
+                CampaignMessage(
+                    id="msg-fail-001",
+                    campaign_id="campaign-retry-001",
+                    contact_id="contact-001",
+                    contact_name="Alice Johnson",
+                    contact_email=["alice@techcorp.com"],
+                    company_name="TechCorp",
+                    subject="",
+                    message="",
+                    status="failed",
+                    error="LLM timeout",
+                ),
+                Contact(
+                    id="contact-001",
+                    company_id="company-001",
+                    name="Alice Johnson",
+                    email=["alice@techcorp.com"],
+                    title="CTO",
+                ),
+                Company(
+                    id="company-001",
+                    name="TechCorp",
+                    industry="Technology",
+                    location="Paris, France",
+                ),
+            ),
+            (
+                CampaignMessage(
+                    id="msg-fail-002",
+                    campaign_id="campaign-retry-001",
+                    contact_id="contact-002",
+                    contact_name="Bob Smith",
+                    contact_email=["bob@innovate.io"],
+                    company_name="Innovate.io",
+                    subject="",
+                    message="",
+                    status="failed",
+                    error="Parsing failure",
+                ),
+                Contact(
+                    id="contact-002",
+                    company_id="company-002",
+                    name="Bob Smith",
+                    email=["bob@innovate.io"],
+                    title="Engineering Manager",
+                ),
+                Company(
+                    id="company-002",
+                    name="Innovate.io",
+                    industry="Software",
+                    location="Lyon, France",
+                ),
+            ),
+        ]
+
+    @staticmethod
+    def parse_sse_event(sse_string: str) -> tuple[str, dict]:
+        """Parse an SSE string into event type and data."""
+        lines = sse_string.strip().split("\n")
+        event_type = ""
+        data = {}
+
+        for line in lines:
+            if line.startswith("event: "):
+                event_type = line[7:]
+            elif line.startswith("data: "):
+                data = json.loads(line[6:])
+                if "event" in data:
+                    event_type = data["event"]
+
+        return event_type, data
+
+    @staticmethod
+    async def collect_events(
+        use_case: RetryCampaignStreamUseCase,
+    ) -> List[tuple[str, dict]]:
+        """Collect all SSE events from the retry stream."""
+        events = []
+        async for sse_string in use_case.retry_campaign_stream():
+            event_type, data = TestRetryCampaignStreamUseCase.parse_sse_event(
+                sse_string
+            )
+            events.append((event_type, data))
+        return events
+
+    def _make_use_case(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        campaign_id: str = CAMPAIGN_ID,
+    ) -> RetryCampaignStreamUseCase:
+        """Create a RetryCampaignStreamUseCase with dependencies."""
+        return RetryCampaignStreamUseCase(
+            campaign_id=campaign_id,
+            profile_repository=fake_profile_repository,
+            campaign_repository=fake_campaign_repository,
+            message_port=fake_message_port,
+        )
+
+    async def test_happy_path_retries_failed_messages(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        completed_campaign: Campaign,
+        failed_messages_with_contacts: List[tuple[CampaignMessage, Contact, Company]],
+    ):
+        """Should retry all failed messages and emit correct events."""
+        fake_profile_repository.set_profile(sample_profile)
+        fake_campaign_repository.add_failed_messages_with_contacts(
+            self.CAMPAIGN_ID, failed_messages_with_contacts
+        )
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        events = await self.collect_events(use_case)
+
+        event_types = [t for t, _ in events]
+
+        # Expected: started, (progress, message) * 2, completed
+        assert event_types == [
+            "campaign_started",
+            "progress_update",
+            "message_generated",
+            "progress_update",
+            "message_generated",
+            "campaign_completed",
+        ]
+
+        # Verify message events are successful
+        message_events = [(t, d) for t, d in events if t == "message_generated"]
+        assert len(message_events) == 2
+        for _, msg_data in message_events:
+            assert msg_data["data"]["status"] == "success"
+
+        # Verify completion counters
+        completed_events = [(t, d) for t, d in events if t == "campaign_completed"]
+        assert len(completed_events) == 1
+        _, completed_data = completed_events[0]
+        assert completed_data["data"]["successful"] == 2
+        assert completed_data["data"]["failed"] == 0
+
+    async def test_no_failed_messages_emits_completion_immediately(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        completed_campaign: Campaign,
+    ):
+        """Should emit completion event with zero retried when no failed messages exist."""
+        fake_profile_repository.set_profile(sample_profile)
+        # No failed messages configured
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        events = await self.collect_events(use_case)
+
+        assert len(events) == 1
+        event_type, data = events[0]
+        assert event_type == "campaign_completed"
+        assert data["data"]["total_contacts"] == 0
+        assert "No failed messages to retry" in data["data"]["message"]
+
+    async def test_campaign_not_found_emits_error(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+    ):
+        """Should emit campaign_failed event when campaign does not exist."""
+        fake_profile_repository.set_profile(sample_profile)
+
+        use_case = self._make_use_case(
+            fake_profile_repository,
+            fake_campaign_repository,
+            fake_message_port,
+            campaign_id="nonexistent-id",
+        )
+        events = await self.collect_events(use_case)
+
+        assert len(events) == 1
+        event_type, data = events[0]
+        assert event_type == "campaign_failed"
+        assert "Campaign not found" in data["data"]["error"]
+
+    async def test_campaign_in_progress_emits_error(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+    ):
+        """Should emit campaign_failed event when campaign is IN_PROGRESS."""
+        fake_profile_repository.set_profile(sample_profile)
+        in_progress_campaign = Campaign(
+            id="campaign-in-progress",
+            name="Active Campaign",
+            status=CampaignStatus.IN_PROGRESS,
+            total_contacts=5,
+        )
+        fake_campaign_repository._campaigns[in_progress_campaign.id] = in_progress_campaign
+
+        use_case = self._make_use_case(
+            fake_profile_repository,
+            fake_campaign_repository,
+            fake_message_port,
+            campaign_id="campaign-in-progress",
+        )
+        events = await self.collect_events(use_case)
+
+        assert len(events) == 1
+        event_type, data = events[0]
+        assert event_type == "campaign_failed"
+        assert "Cannot retry campaign with status" in data["data"]["error"]
+
+    async def test_partial_failures_updates_counters_correctly(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        completed_campaign: Campaign,
+        failed_messages_with_contacts: List[tuple[CampaignMessage, Contact, Company]],
+    ):
+        """Should correctly update counters when some retries fail again."""
+        fake_profile_repository.set_profile(sample_profile)
+        fake_campaign_repository.add_failed_messages_with_contacts(
+            self.CAMPAIGN_ID, failed_messages_with_contacts
+        )
+        # Make second contact fail again
+        fake_message_port.set_should_fail_for("contact-002")
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        events = await self.collect_events(use_case)
+
+        # Verify message statuses
+        message_events = [(t, d) for t, d in events if t == "message_generated"]
+        assert len(message_events) == 2
+        _, first_msg = message_events[0]
+        assert first_msg["data"]["status"] == "success"
+        _, second_msg = message_events[1]
+        assert second_msg["data"]["status"] == "failed"
+
+        # Verify completion counters
+        completed_events = [(t, d) for t, d in events if t == "campaign_completed"]
+        _, completed_data = completed_events[0]
+        assert completed_data["data"]["successful"] == 1
+        assert completed_data["data"]["failed"] == 1
+
+        # Verify campaign state: previous_successful (1) + new_successful (1) = 2
+        campaign = fake_campaign_repository._campaigns[self.CAMPAIGN_ID]
+        assert campaign.status == CampaignStatus.COMPLETED
+        assert campaign.successful == 2  # 1 previous + 1 new
+        assert campaign.failed == 1
+        assert campaign.completed_at is not None
+
+    async def test_no_profile_emits_error(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        completed_campaign: Campaign,
+    ):
+        """Should emit campaign_failed event when profile does not exist."""
+        # Profile repository is empty by default
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        events = await self.collect_events(use_case)
+
+        assert len(events) == 1
+        event_type, data = events[0]
+        assert event_type == "campaign_failed"
+        assert "Profile not found" in data["data"]["error"]
+
+    async def test_old_messages_are_deleted_before_regeneration(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        completed_campaign: Campaign,
+        failed_messages_with_contacts: List[tuple[CampaignMessage, Contact, Company]],
+    ):
+        """Should delete old failed messages before generating new ones."""
+        fake_profile_repository.set_profile(sample_profile)
+        fake_campaign_repository.add_failed_messages_with_contacts(
+            self.CAMPAIGN_ID, failed_messages_with_contacts
+        )
+        # Pre-populate messages in the repository
+        for msg, _, _ in failed_messages_with_contacts:
+            fake_campaign_repository._messages[msg.id] = msg
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        await self.collect_events(use_case)
+
+        # Old message IDs should no longer exist
+        assert "msg-fail-001" not in fake_campaign_repository._messages
+        assert "msg-fail-002" not in fake_campaign_repository._messages
+
+        # New messages should exist (2 new ones)
+        all_messages = fake_campaign_repository.get_all_messages()
+        assert len(all_messages) == 2
+        assert all(m.status == "success" for m in all_messages)
+
+    async def test_all_retries_fail_marks_campaign_failed(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        completed_campaign: Campaign,
+        failed_messages_with_contacts: List[tuple[CampaignMessage, Contact, Company]],
+    ):
+        """Should mark campaign as FAILED when all retries fail again."""
+        fake_profile_repository.set_profile(sample_profile)
+        fake_campaign_repository.add_failed_messages_with_contacts(
+            self.CAMPAIGN_ID, failed_messages_with_contacts
+        )
+        # Make all contacts fail
+        fake_message_port.set_should_fail_for("contact-001")
+        fake_message_port.set_should_fail_for("contact-002")
+
+        use_case = self._make_use_case(
+            fake_profile_repository, fake_campaign_repository, fake_message_port
+        )
+        await self.collect_events(use_case)
+
+        campaign = fake_campaign_repository._campaigns[self.CAMPAIGN_ID]
+        assert campaign.status == CampaignStatus.FAILED
+        assert campaign.failed == 2
+        # Previous successful stays
+        assert campaign.successful == 1
+
+    async def test_retry_on_failed_campaign_status(
+        self,
+        fake_profile_repository: FakeProfileRepository,
+        fake_campaign_repository: FakeCampaignRepository,
+        fake_message_port: FakeGenerateMessagePort,
+        sample_profile: Profile,
+        failed_messages_with_contacts: List[tuple[CampaignMessage, Contact, Company]],
+    ):
+        """Should allow retry on campaigns with FAILED status."""
+        fake_profile_repository.set_profile(sample_profile)
+        failed_campaign = Campaign(
+            id="campaign-failed-001",
+            name="Failed Campaign",
+            status=CampaignStatus.FAILED,
+            total_contacts=2,
+            successful=0,
+            failed=2,
+        )
+        fake_campaign_repository._campaigns[failed_campaign.id] = failed_campaign
+        fake_campaign_repository.add_failed_messages_with_contacts(
+            "campaign-failed-001", failed_messages_with_contacts
+        )
+
+        use_case = self._make_use_case(
+            fake_profile_repository,
+            fake_campaign_repository,
+            fake_message_port,
+            campaign_id="campaign-failed-001",
+        )
+        events = await self.collect_events(use_case)
+
+        event_types = [t for t, _ in events]
+        assert "campaign_started" in event_types
+        assert "campaign_completed" in event_types


### PR DESCRIPTION
## Summary
- Add `POST /campaigns/{campaign_id}/retry/stream` SSE endpoint that re-generates only failed messages of completed/failed campaigns
- Add `get_failed_messages_with_contacts` and `delete_message` methods to `CampaignRepositoryPort` and its PostgreSQL adapter
- Create `RetryCampaignStreamUseCase` following the same patterns as `GenerateCampaignStreamUseCase`
- Add 9 unit tests covering happy path, no failed messages, campaign not found, invalid status, partial failures, no profile, message deletion, all retries failing, and retry on FAILED status campaigns

## Test plan
- [x] All 554 tests pass (`uv run pytest -q`)
- [ ] Manual test: retry campaign with failed messages via SSE stream
- [ ] Manual test: retry campaign with no failed messages returns immediate completion
- [ ] Manual test: retry campaign with invalid status returns error event
- [ ] Verify CI pipeline passes